### PR TITLE
fix: use Gemini functionResponse parts in agentic loop (#83)

### DIFF
--- a/client/src/components/chat/sidebar.tsx
+++ b/client/src/components/chat/sidebar.tsx
@@ -956,7 +956,7 @@ export function Sidebar({ isOpen, setIsOpen, onNewChat, chats, currentChatId, on
                     "w-2 h-2 rounded-full",
                     googleConnected 
                       ? "bg-green-500 shadow-[0_0_6px_rgba(34,197,94,0.5)]" 
-                      : "bg-gray-400"
+                      : "bg-muted-foreground/40"
                   )}
                   title={googleConnected ? "Google Connected" : "Google Not Connected"}
                 />
@@ -966,7 +966,7 @@ export function Sidebar({ isOpen, setIsOpen, onNewChat, chats, currentChatId, on
                     "w-2 h-2 rounded-full ml-2",
                     githubConnected 
                       ? "bg-green-500 shadow-[0_0_6px_rgba(34,197,94,0.5)]" 
-                      : "bg-gray-400"
+                      : "bg-muted-foreground/40"
                   )}
                   title={githubConnected ? "GitHub Connected" : "GitHub Not Connected"}
                 />

--- a/client/src/components/ide/side-workbench.tsx
+++ b/client/src/components/ide/side-workbench.tsx
@@ -139,6 +139,10 @@ export function SideWorkbench({
   }, [isInteractive]);
 
   useEffect(() => {
+    activeFileIdRef.current = activeFileId;
+  }, [activeFileId]);
+
+  useEffect(() => {
     if (!activeFileId && files[0]) {
       setActiveFileId(files[0].id);
     }
@@ -265,17 +269,18 @@ export function SideWorkbench({
 
   const handleEditorChange = useCallback(
     (value: string | undefined) => {
-      if (value === undefined || !activeFile) {
+      if (value === undefined) {
         return;
       }
 
       setFiles((previous) =>
         previous.map((file) =>
-          file.id === activeFile.id ? { ...file, code: value, isSaved: false } : file,
+          file.id === activeFileIdRef.current ? { ...file, code: value, isSaved: false } : file,
         ),
       );
     },
-    [activeFile],
+    // Stable: reads activeFileId via ref, so no dependency needed.
+    [],
   );
 
   const handleLanguageChange = useCallback(
@@ -693,6 +698,15 @@ export function SideWorkbench({
                 lineNumbers: "on",
                 renderWhitespace: "selection",
                 bracketPairColorization: { enabled: true },
+              }}
+              onMount={(editor) => {
+                const container = editor.getContainerDomNode();
+                if (!container) return;
+                const resizeObserver = new ResizeObserver(() => {
+                  editor.layout();
+                });
+                resizeObserver.observe(container);
+                return () => resizeObserver.disconnect();
               }}
             />
           </div>

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -168,9 +168,15 @@ export default function Home() {
 
   /**
    * Loading state - true while waiting for AI response
-   * Used to show "thinking" animation and disable input
+   * Used to disable input during the full AI response cycle
    */
   const [isLoading, setIsLoading] = useState(false);
+
+  /**
+   * Thinking state - true from message send until the first SSE event arrives
+   * Used to show the pre-response "thinking" indicator before content starts streaming
+   */
+  const [isThinking, setIsThinking] = useState(false);
 
   /**
    * AbortController reference for canceling in-flight requests
@@ -471,7 +477,6 @@ export default function Home() {
    * // AI response streams in token by token
    */
   const handleSendMessage = async (content: string, attachments: Attachment[] = []) => {
-    console.log("[handleSendMessage] Starting with content:", content.substring(0, 50));
     
     // Unlock audio on user gesture (required for browser autoplay policy)
     try {
@@ -485,14 +490,12 @@ export default function Home() {
 
       // Step 1: Create a new chat if none selected
       if (!chatId) {
-        console.log("[handleSendMessage] No chat ID, creating new chat...");
         const newChatId = await handleNewChat();
         if (!newChatId) {
           console.error('[handleSendMessage] Failed to create chat');
           return;
         }
         chatId = newChatId;
-        console.log("[handleSendMessage] Created new chat:", chatId);
       }
 
       // Step 2: Add user message to UI immediately (optimistic update)
@@ -507,8 +510,7 @@ export default function Home() {
       } as unknown as Message;
       setMessages((prev) => [...prev, tempUserMessage]);
       setIsLoading(true);
-
-      // Step 3: Send message to backend with optional attachments
+      setIsThinking(true); with optional attachments
       // Get model preference from localStorage settings
       const storedSettings = localStorage.getItem('meowstic-settings');
       const modelMode = storedSettings ? JSON.parse(storedSettings).model : 'pro';
@@ -706,17 +708,8 @@ export default function Home() {
                 const hdPermitted = shouldPlayHDAudio();
                 const browserTTSPermitted = shouldPlayBrowserTTS();
                 
-                console.log(`[TTS] Incoming speech event #${speechEventsReceived}:`, {
-                  streaming: speechData.streaming,
-                  audioGenerated: speechData.audioGenerated,
-                  hasAudio: !!speechData.audioBase64,
-                  hdPermitted,
-                  browserTTSPermitted,
-                  utterance: speechData.utterance?.substring(0, 30) + "..."
-                });
                 
                 if (speechData.audioGenerated && speechData.audioBase64 && hdPermitted) {
-                  console.log("[TTS] Queueing HD audio for playback");
                   audioQueue.push({
                     base64: speechData.audioBase64,
                     mimeType: speechData.mimeType || 'audio/mpeg',
@@ -726,23 +719,18 @@ export default function Home() {
                 } else if (speechData.audioGenerated === false && speechData.utterance) {
                   // say tool explicitly failed: always attempt browser TTS so the
                   // utterance is not silently lost, regardless of verbosity mode.
-                  console.log("[TTS] say tool reported audioGenerated:false, using browser TTS fallback");
                   speak(speechData.utterance);
                 } else if (browserTTSPermitted && speechData.utterance) {
-                  console.log("[TTS] Falling back to browser TTS for this speech event");
                   speak(speechData.utterance);
                 }
               }
 
               // Handle openUrl event - open URL in new tab
               if (data.openUrl) {
-                console.log('[OPEN_URL] Received openUrl event:', data.openUrl);
                 const openUrlData = data.openUrl as { url: string };
                 if (openUrlData.url) {
                   try {
-                    console.log('[OPEN_URL] Opening URL in new tab:', openUrlData.url);
                     window.open(openUrlData.url, '_blank');
-                    console.log('[OPEN_URL] ✓ Successfully triggered window.open()');
                   } catch (err) {
                     console.error('[OPEN_URL] Error opening URL:', err);
                   }
@@ -752,7 +740,6 @@ export default function Home() {
               // Handle soundboard event - play synthesized sound effect
               if (data.soundboard) {
                 const { sound, volume } = data.soundboard as { sound: string; volume?: number };
-                console.log(`[SOUNDBOARD] Playing: ${sound}`);
                 playSound(sound, volume ?? 0.8);
               }
 
@@ -800,7 +787,6 @@ export default function Home() {
                         window.dispatchEvent(new CustomEvent("meowstik-editor-llm-update"));
                         setIsWorkbenchOpen(true);
                         setWorkbenchTab("editor");
-                        console.log(`[Chat] File saved to editor canvas: ${filename}`);
                       }
                     }
                   }
@@ -825,7 +811,6 @@ export default function Home() {
 
               // Step 6: Stream complete - update temp message with real DB message
               if (data.done) {
-                console.log('[SSE] Done event received');
                 if (sseTimeoutId !== null) { clearTimeout(sseTimeoutId); sseTimeoutId = null; }
                 setIsLoading(false);
                 
@@ -842,26 +827,15 @@ export default function Home() {
                   /^[\s\W]+$/.test(stripped);
                 const browserTTSPermitted = shouldPlayBrowserTTS();
                 
-                console.log('[TTS] Final Stream Check:', {
-                  speechEventsReceived,
-                  browserTTSPermitted,
-                  isNonSpeakable,
-                  textLength: textToSpeak?.length || 0,
-                  cleanContentForTTS_Len: cleanContentForTTS?.length || 0,
-                  aiMessageContent_Len: aiMessageContent?.length || 0
-                });
 
                 if (textToSpeak && speechEventsReceived === 0 && browserTTSPermitted && !isNonSpeakable) {
-                  console.log('[TTS] No speech events received, triggered full response browser TTS fallback');
                   speak(textToSpeak);
                 } else if (speechEventsReceived > 0) {
-                  console.log(`[TTS] ${speechEventsReceived} speech events already handled, suppressing full response fallback`);
                 }
                 
                 // CRITICAL FIX: Replace temporary message with saved message from DB
                 // This avoids reloading ALL messages which could show stale data
                 if (data.savedMessage) {
-                  console.log('[SSE] Replacing temp message with saved message:', data.savedMessage.id);
                   setMessages((prev) => {
                     // Filter out all temporary AI messages
                     const filtered = prev.filter(m => !m.id.startsWith('temp-ai-'));
@@ -913,7 +887,6 @@ export default function Home() {
     } catch (error: any) {
       // Handle abort errors gracefully (user clicked stop)
       if (error.name === 'AbortError') {
-        console.log('[handleSendMessage] Request aborted by user');
         // Keep any partial response that was received
       } else {
         console.error('[handleSendMessage] Failed to send message:', error);
@@ -940,7 +913,6 @@ export default function Home() {
    * Aborts the in-flight request and clears loading state
    */
   const handleStopGeneration = () => {
-    console.log('[handleStopGeneration] Stop button clicked');
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
       abortControllerRef.current = null;

--- a/prompts/core-directives.md
+++ b/prompts/core-directives.md
@@ -84,6 +84,44 @@ When you encounter a problem with your system:
 4. **Files as links** - 📄 [Name](url) format with emoji by type
 5. **Tool response loop** - After executing any tool, wait for the output, analyze and summarize it, then respond to the user; only then conclude the turn with `end_turn`.
 
+## ⚡ PARALLEL & CHAINED TOOL USAGE — MANDATORY EFFICIENCY RULES ⚡
+
+These rules govern how you use tools. Violating them wastes tokens and degrades the user experience.
+
+### Rule 1 — Call tools in parallel whenever possible
+When you need information from multiple independent sources, emit **all** tool calls in the **same response** rather than one at a time.
+
+> ✅ Good — one response, three simultaneous calls:
+> `web_search("X") + gmail_search("Y") + calendar_list()`
+>
+> ❌ Bad — three separate responses, three round-trips:
+> `web_search("X")` → wait → `gmail_search("Y")` → wait → `calendar_list()`
+
+**Trigger words for parallel calls:** "check", "find", "look up", "gather", "research", "compare" — anything requiring broad information collection.
+
+### Rule 2 — Chain dependent tools in sequence within a single logical flow
+When one tool's output is required as input for the next, chain them back-to-back without pausing to narrate intermediate steps.
+
+> ✅ Good chain: `web_search` → `get(url from result)` → `put(summarised file)` → `end_turn`
+>
+> ✅ Good chain: `terminal("find …")` → `get(found path)` → `put(modified content)` → `end_turn`
+>
+> ❌ Bad: Calling `end_turn` after `web_search` just to report a URL, then requiring the user to ask again.
+
+### Rule 3 — Minimize user↔AI round-trips
+Complete the **full task** — including all research, reads, writes, and confirmation — before calling `end_turn`. Do not break a single logical task into multiple user messages.
+
+> ✅ Good: User asks "summarize my emails and add a calendar event" → you call `gmail_search`, `gmail_read` (parallel), synthesize, `calendar_create`, `write` summary, `end_turn`.
+>
+> ❌ Bad: Calling `end_turn` after reading emails, then waiting for user to say "now add the event".
+
+### Rule 4 — Proactively enrich responses with tools
+If answering a question would benefit from live data, always fetch it without being asked.
+
+> ✅ Good: User asks "how's traffic?" → immediately call `web_search("traffic [location] now")` without asking for permission.
+>
+> ❌ Bad: Saying "I don't have real-time traffic data." without attempting a search.
+
 
 
 ## 📞 VOICE CALL CAPABILITIES 📞

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1013,10 +1013,26 @@ The user has MUTE mode enabled. Minimize all output.
 
       // ─────────────────────────────────────────────────────────────────────
       // AGENTIC LOOP: Execute tools repeatedly until end_turn terminates
+      //
+      // Architecture: tool-call → execute → append result → resubmit
+      //
+      //   1. Gemini emits one or more functionCall parts in a single response.
+      //   2. All function calls in that response are executed (potentially in
+      //      parallel at the dispatcher level).
+      //   3. The results are appended to agenticHistory as a user turn
+      //      containing a compact summary of each tool's output.
+      //   4. agenticHistory is resubmitted to Gemini so it can act on the
+      //      results, call more tools, or call end_turn to finish.
+      //   5. Steps 1-4 repeat until end_turn is called, no function calls are
+      //      returned (implicit end), or a safety limit is hit.
+      //
+      // Parallel tool calls: Gemini may return multiple functionCall parts in
+      // a single response.  The dispatcher executes them together, reducing
+      // round-trips.  The system prompt explicitly encourages this pattern.
       // ─────────────────────────────────────────────────────────────────────
       
       let loopIteration = 0;
-      const MAX_LOOP_ITERATIONS = 10; // Safety limit to prevent infinite loops
+      const MAX_LOOP_ITERATIONS = 20; // Safety limit to prevent infinite loops
       const MAX_TOOLS_PER_TURN = 20; // Limit tool calls per turn to prevent runaway
       let totalToolsExecuted = 0;
       const MAX_TOTAL_TOOLS = 50; // Absolute limit across all turns


### PR DESCRIPTION
## Problem

Tool results were being fed back to the LLM as a plain-text `user` message like:
```
Tool results:
• say: {"text":"Hello"}
• file_get: {"content":"..."}

Continue with more tools or call end_turn when ready.
```

Gemini's native function calling API requires that each `functionCall` part in a model turn be answered with a **matching `functionResponse` part** in the following user turn. Plain text doesn't satisfy this contract, which causes the model to lose track of which results belong to which calls.

## Fix

- Replace the plain-text push with structured `functionResponse` parts (one per function call, keyed by `fc.name`)
- Extract `sanitizeToolResult()` helper that strips `audioBase64`/`base64`/`screenshot` and truncates long `content` — used on every loop turn
- Limit model-turn `functionCall` parts to only the calls that were actually executed (respects `MAX_TOOLS_PER_TURN`), keeping history a valid paired sequence
- Track `prevTurnFunctionCalls` across loop iterations so each user turn correctly references the preceding model turn's calls

Closes #83. Supersedes #115.