### PR TITLE
Fix live mode and top issue regressions

### DIFF
--- a/server/integrations/gemini-live.ts
+++ b/server/integrations/gemini-live.ts
@@ -35,12 +35,21 @@ export interface LiveSessionConfig {
   tools?: any[]; // Additional custom tools
 }
 
+export interface LiveCloseInfo {
+  code?: number;
+  reason?: string;
+  wasClean?: boolean;
+}
+
 export interface LiveSession {
   id: string;
   session: any;
   isActive: boolean;
   createdAt: Date;
   emitter?: EventEmitter;
+  config: LiveSessionConfig;
+  modelName: string;
+  lastClose?: LiveCloseInfo;
 }
 
 const activeSessions = new Map<string, LiveSession>();
@@ -50,6 +59,103 @@ You are having a real-time voice conversation. Be concise and natural in your re
 Respond conversationally as if speaking to a friend. Avoid long lists or overly formal language.`;
 
 const DEFAULT_VOICE = DEFAULT_TTS_VOICE;
+
+const COMPUTER_USE_SYSTEM_INSTRUCTION = `
+
+You have computer control capabilities. You can see the user's screen and control their computer through:
+- computer_click: Click at coordinates
+- computer_type: Type text
+- computer_key: Press keyboard keys
+- computer_scroll: Scroll the screen
+- computer_move: Move the mouse
+- computer_screenshot: Take a screenshot
+- computer_wait: Wait before next action
+
+Use these tools to help the user accomplish tasks hands-free through voice commands.`;
+
+function buildSystemInstructionText(config: LiveSessionConfig = {}) {
+  const instruction = config.systemInstruction || DEFAULT_SYSTEM_INSTRUCTION;
+
+  if (!config.enableComputerUse) {
+    return instruction;
+  }
+
+  return `${instruction}${COMPUTER_USE_SYSTEM_INSTRUCTION}`;
+}
+
+export function buildLiveSessionRequestConfig(config: LiveSessionConfig = {}) {
+  const sessionConfig: any = {
+    // Native-audio Live sessions reject AUDIO+TEXT at setup time. AUDIO mode still
+    // returns text/thought parts alongside PCM chunks in serverContent messages.
+    responseModalities: [Modality.AUDIO],
+    speechConfig: {
+      voiceConfig: {
+        prebuiltVoiceConfig: {
+          voiceName: config.voiceName || DEFAULT_VOICE,
+        },
+      },
+    },
+    systemInstruction: {
+      parts: [{ text: buildSystemInstructionText(config) }],
+    },
+  };
+
+  // Video is streamed as input frames via sendRealtimeInput; it is not a response modality.
+  if (config.enableVideoStreaming && config.useGemini3) {
+    console.log("[Gemini Live] Video streaming input enabled");
+  }
+
+  return sessionConfig;
+}
+
+function normalizeLiveErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error || "Unknown live session error");
+}
+
+export function isRetryableLiveClose(closeInfo?: LiveCloseInfo): boolean {
+  if (!closeInfo) {
+    return false;
+  }
+
+  return (
+    closeInfo.code === 1011 ||
+    /service is currently unavailable/i.test(closeInfo.reason || "")
+  );
+}
+
+export function getLiveCloseErrorMessage(closeInfo?: LiveCloseInfo): string | undefined {
+  if (!closeInfo) {
+    return "Live session closed unexpectedly.";
+  }
+
+  const reason = closeInfo.reason?.trim();
+
+  if (closeInfo.code === 1000 && !reason) {
+    return undefined;
+  }
+
+  if (reason) {
+    return `Live session closed: ${reason}`;
+  }
+
+  if (typeof closeInfo.code === "number") {
+    return `Live session closed with code ${closeInfo.code}.`;
+  }
+
+  return "Live session closed unexpectedly.";
+}
+
+function getInactiveSessionError(liveSession: LiveSession): string {
+  const closeMessage = getLiveCloseErrorMessage(liveSession.lastClose);
+
+  if (!closeMessage) {
+    return "Session not found or inactive";
+  }
+
+  return isRetryableLiveClose(liveSession.lastClose)
+    ? `${closeMessage} Please retry.`
+    : closeMessage;
+}
 
 /**
  * Create a new Gemini Live session
@@ -69,27 +175,10 @@ export async function createLiveSession(
 
   try {
     const ai = new GoogleGenAI({ apiKey });
-    
-    const sessionConfig: any = {
-      responseModalities: [Modality.AUDIO], // Try AUDIO only first
-      /* speechConfig: {
-        voiceConfig: {
-          prebuiltVoiceConfig: {
-            voiceName: config.voiceName || DEFAULT_VOICE
-          }
-        }
-      },
-      systemInstruction: config.systemInstruction || DEFAULT_SYSTEM_INSTRUCTION */
-    };
+    const sessionConfig = buildLiveSessionRequestConfig(config);
 
     // Add video streaming support for Gemini 3.0 (Project Ghost)
     if (config.enableVideoStreaming && config.useGemini3) {
-      // Enable video input modality for continuous streaming
-      // Note: "VIDEO" is not yet in the Modality enum; use string literal for forward compatibility
-      const VIDEO_MODALITY = "VIDEO" as unknown as typeof Modality.AUDIO;
-      if (!sessionConfig.responseModalities.includes(VIDEO_MODALITY)) {
-        sessionConfig.responseModalities.push(VIDEO_MODALITY);
-      }
       console.log(`[Gemini Live] Video streaming enabled for session ${sessionId}`);
     }
 
@@ -103,20 +192,6 @@ export async function createLiveSession(
       );
       
       sessionConfig.tools = computerUseTools;
-      
-      // Update system instruction to include Computer Use capabilities
-      sessionConfig.systemInstruction = `${sessionConfig.systemInstruction}
-
-You have computer control capabilities. You can see the user's screen and control their computer through:
-- computer_click: Click at coordinates
-- computer_type: Type text
-- computer_key: Press keyboard keys
-- computer_scroll: Scroll the screen
-- computer_move: Move the mouse
-- computer_screenshot: Take a screenshot
-- computer_wait: Wait before next action
-
-Use these tools to help the user accomplish tasks hands-free through voice commands.`;
     }
 
     // Add any additional custom tools
@@ -147,8 +222,18 @@ Use these tools to help the user accomplish tasks hands-free through voice comma
               emitter.emit('message', msg);
           },
           onclose: (e: any) => {
-               console.log(`[Gemini Live] Session ${sessionId} closed`, e);
-               emitter.emit('close', e);
+               const closeInfo: LiveCloseInfo = {
+                 code: e?.code,
+                 reason: e?.reason,
+                 wasClean: e?.wasClean,
+               };
+               const currentSession = activeSessions.get(sessionId);
+               if (currentSession) {
+                 currentSession.isActive = false;
+                 currentSession.lastClose = closeInfo;
+               }
+               console.log(`[Gemini Live] Session ${sessionId} closed`, closeInfo);
+               emitter.emit('close', closeInfo);
           },
           onerror: (err: any) => {
                console.error(`[Gemini Live] Session ${sessionId} error`, err);
@@ -162,7 +247,9 @@ Use these tools to help the user accomplish tasks hands-free through voice comma
       session,
       isActive: true,
       createdAt: new Date(),
-      emitter
+      emitter,
+      config: { ...config },
+      modelName,
     });
     
     // Check if session has conn property (SDK v1.42+ behavior)
@@ -201,7 +288,10 @@ export async function sendAudio(
   const liveSession = activeSessions.get(sessionId);
   
   if (!liveSession || !liveSession.isActive) {
-    return { success: false, error: "Session not found or inactive" };
+    return {
+      success: false,
+      error: liveSession ? getInactiveSessionError(liveSession) : "Session not found or inactive",
+    };
   }
 
   try {
@@ -252,7 +342,10 @@ export async function sendVideoFrame(
   const liveSession = activeSessions.get(sessionId);
   
   if (!liveSession || !liveSession.isActive) {
-    return { success: false, error: "Session not found or inactive" };
+    return {
+      success: false,
+      error: liveSession ? getInactiveSessionError(liveSession) : "Session not found or inactive",
+    };
   }
 
   try {
@@ -338,10 +431,12 @@ export async function sendText(
 export async function* receiveResponses(
   sessionId: string
 ): AsyncGenerator<{
-  type: "audio" | "text" | "transcript" | "functionCall" | "end";
+  type: "audio" | "text" | "transcript" | "functionCall" | "error" | "end";
   data?: string;
   text?: string;
-  functionCall?: { name: string; args: any };
+  error?: string;
+  retryable?: boolean;
+  functionCall?: { id?: string; name: string; args: any };
 }> {
   const liveSession = activeSessions.get(sessionId);
   
@@ -353,20 +448,24 @@ export async function* receiveResponses(
   // If we have an emitter (new SDK path)
   if (liveSession.emitter) {
       const emitter = liveSession.emitter;
-      const queue: any[] = [];
+      const queue: Array<
+        | { kind: "message"; message: any }
+        | { kind: "close"; closeInfo: LiveCloseInfo }
+        | { kind: "error"; error: string }
+      > = [];
       let resolveNext: ((value?: any) => void) | null = null;
-      let rejectNext: ((reason?: any) => void) | null = null;
       let ended = false;
 
       const onMessage = (msg: any) => {
-          queue.push(msg);
+          queue.push({ kind: "message", message: msg });
           if (resolveNext) {
               resolveNext();
               resolveNext = null;
           }
       };
 
-      const onClose = () => {
+      const onClose = (closeInfo: LiveCloseInfo) => {
+          queue.push({ kind: "close", closeInfo });
           ended = true;
           if (resolveNext) {
               resolveNext();
@@ -375,9 +474,12 @@ export async function* receiveResponses(
       };
 
       const onError = (err: any) => {
+           queue.push({ kind: "error", error: normalizeLiveErrorMessage(err) });
            ended = true;
-           if (rejectNext) rejectNext(err);
-           if (resolveNext) resolveNext();
+           if (resolveNext) {
+             resolveNext();
+             resolveNext = null;
+           }
       };
 
       emitter.on('message', onMessage);
@@ -387,23 +489,41 @@ export async function* receiveResponses(
       try {
           while (!ended || queue.length > 0) {
               if (queue.length === 0) {
-                  await new Promise<void>((resolve, reject) => {
+                  await new Promise<void>((resolve) => {
                       resolveNext = resolve;
-                      rejectNext = reject;
                   });
               }
               
               if (queue.length === 0 && ended) break;
               
               while (queue.length > 0) {
-                  const msg = queue.shift();
-                  
-                  // The message structure depends on the SDK version
-                  // It might be { serverContent: ... } or just raw object if parsed
-                  
-                  // Log message structure to help debugging
-                  // console.log("Processing msg keys:", Object.keys(msg));
-                  
+                  const event = queue.shift();
+                  if (!event) {
+                    continue;
+                  }
+
+                  if (event.kind === "close") {
+                      const errorMessage = getLiveCloseErrorMessage(event.closeInfo);
+                      if (errorMessage) {
+                          yield {
+                            type: "error",
+                            error: errorMessage,
+                            retryable: isRetryableLiveClose(event.closeInfo),
+                          };
+                      }
+                      continue;
+                  }
+
+                  if (event.kind === "error") {
+                      yield {
+                        type: "error",
+                        error: event.error,
+                      };
+                      continue;
+                  }
+
+                  const msg = event.message;
+
                   if (msg.serverContent) {
                       const { modelTurn } = msg.serverContent;
                       if (modelTurn && modelTurn.parts) {
@@ -411,7 +531,7 @@ export async function* receiveResponses(
                               if (part.inlineData) {
                                   yield { type: "audio", data: part.inlineData.data };
                               }
-                              if (part.text) {
+                              if (part.text && !part.thought) {
                                   yield { type: "transcript", text: part.text };
                                   yield { type: "text", text: part.text };
                               }
@@ -468,7 +588,7 @@ export async function* receiveResponses(
               if (part.inlineData) {
                 yield { type: "audio", data: part.inlineData.data };
               }
-              if (part.text) {
+              if (part.text && !part.thought) {
                 yield { type: "transcript", text: part.text };
               }
               // Handle function calls from Computer Use (Project Ghost)
@@ -484,11 +604,41 @@ export async function* receiveResponses(
             }
           }
         }
-    } catch (error) {
+  } catch (error) {
     console.error("[Gemini Live] Error receiving responses:", error);
+    yield {
+      type: "error",
+      error: normalizeLiveErrorMessage(error),
+    };
   }
   
   yield { type: "end" };
+}
+
+export async function recreateLiveSession(
+  sessionId: string,
+): Promise<{ success: boolean; error?: string }> {
+  const liveSession = activeSessions.get(sessionId);
+
+  if (!liveSession) {
+    return { success: false, error: "Session not found" };
+  }
+
+  if (liveSession.isActive) {
+    try {
+      if (typeof liveSession.session.close === "function") {
+        await liveSession.session.close();
+      } else if (liveSession.session.conn) {
+        liveSession.session.conn.close();
+      }
+    } catch (error) {
+      console.warn(`[Gemini Live] Failed to close session before recreating ${sessionId}:`, error);
+    }
+  }
+
+  activeSessions.delete(sessionId);
+
+  return createLiveSession(sessionId, liveSession.config);
 }
 
 /**
@@ -668,6 +818,5 @@ export const AVAILABLE_VOICES = [
   { value: "Orus", label: "Orus - Authoritative Male", gender: "male" },
   { value: "Zephyr", label: "Zephyr - Gentle Neutral", gender: "neutral" },
 ] as const;
-
 
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -675,11 +675,11 @@ export async function registerRoutes(
               const limitedResult = hasNoTruncate ? resultStr : resultStr.slice(0, 5000);
               return `[Tool ${tr.type} returned: ${limitedResult}]`;
             })
-            .join("\\n");
-          content = content + "\\n\\n" + toolSummary;
+            .join("\n");
+          content = content + "\n\n" + toolSummary;
         } else if (content.length > MAX_CONTENT_LENGTH) {
           // Truncate older messages if too long
-          content = content.slice(0, MAX_CONTENT_LENGTH) + "\\n...[truncated for context]";
+          content = content.slice(0, MAX_CONTENT_LENGTH) + "\n...[truncated for context]";
         }
         
         return {

--- a/server/routes/twilio.ts
+++ b/server/routes/twilio.ts
@@ -19,6 +19,8 @@ import { eq, or, desc } from "drizzle-orm";
 import { log } from "../vite.js";
 
 const { VoiceResponse } = twilio.twiml;
+const OWNER_NAME = "Jason Bender";
+const DEFAULT_TWILIO_TEXT_MODEL = process.env.GEMINI_SMS_MODEL || "gemini-2.5-flash";
 
 export const twilioRouter = Router();
 
@@ -358,6 +360,9 @@ twilioRouter.post("/sms", async (req, res) => {
       // ── Generate Meowstik AI reply ─────────────────────────────────────────
       if (!process.env.GEMINI_API_KEY) {
         log("⚠️ [Twilio] GEMINI_API_KEY not set — skipping AI reply");
+        await db.update(smsMessages)
+          .set({ processed: true, processedAt: new Date() })
+          .where(eq(smsMessages.messageSid, inboundMessageSid));
         return;
       }
 
@@ -376,24 +381,28 @@ twilioRouter.post("/sms", async (req, res) => {
         .map((m) => `${m.direction === "inbound" ? "Them" : "Meowstik"}: ${m.body}`)
         .join("\n");
 
-      const ownerName = "Jason Bender";
       const systemInstruction = isFromOwner
-        ? `You are Meowstik, ${ownerName}'s AI assistant. ${ownerName} is texting you. Help him. Be concise.`
-        : `You are Meowstik, the AI phone assistant for ${ownerName}. Someone is texting the Meowstik number. ` +
-          `Be helpful and warm. Keep replies to 1-3 sentences. You can take messages for ${ownerName}.`;
+        ? `You are Meowstik, ${OWNER_NAME}'s AI assistant. ${OWNER_NAME} is texting you. Help him. Be concise.`
+        : `You are Meowstik, the AI phone assistant for ${OWNER_NAME}. Someone is texting the Meowstik number. ` +
+          `Be helpful and warm. Keep replies to 1-3 sentences. You can take messages for ${OWNER_NAME}.`;
 
       const prompt = history
         ? `Conversation so far:\n${history}\n\nNew message: ${Body}\n\nReply:`
         : `Message: ${Body}\n\nReply:`;
 
       const result = await ai.models.generateContent({
-        model: "gemini-2.0-flash",
+        model: DEFAULT_TWILIO_TEXT_MODEL,
         config: { systemInstruction },
         contents: [{ role: "user", parts: [{ text: prompt }] }],
       });
 
       const reply = result.text?.trim();
-      if (!reply) return;
+      if (!reply) {
+        await db.update(smsMessages)
+          .set({ processed: true, processedAt: new Date() })
+          .where(eq(smsMessages.messageSid, inboundMessageSid));
+        return;
+      }
 
       const { sendSMS } = await import("../integrations/twilio.js");
       const sent = await sendSMS(From, reply);
@@ -408,6 +417,14 @@ twilioRouter.post("/sms", async (req, res) => {
         status: "sent",
         processed: true,
       });
+
+      await db.update(smsMessages)
+        .set({
+          responseMessageSid: sent?.sid || null,
+          processed: true,
+          processedAt: new Date(),
+        })
+        .where(eq(smsMessages.messageSid, inboundMessageSid));
 
       log(`💬 [Twilio] Meowstik replied to ${From}: "${reply.slice(0, 80)}"`);
     } catch (err) {
@@ -444,7 +461,7 @@ async function handleOwnerCallCommand(
     const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
 
     const parseResult = await ai.models.generateContent({
-      model: "gemini-2.0-flash",
+      model: DEFAULT_TWILIO_TEXT_MODEL,
       config: {
         systemInstruction:
           "Extract the call request details from the user's message. " +
@@ -545,6 +562,3 @@ async function handleOwnerCallCommand(
 }
 
 export default twilioRouter;
-
-
-

--- a/server/websocket-live.ts
+++ b/server/websocket-live.ts
@@ -20,6 +20,10 @@ interface LiveWebSocketClient {
   sessionId: string;
   isActive: boolean;
   desktopSessionId?: string; // For Computer Use integration
+  lastTextTurn?: string;
+  awaitingTextResponse: boolean;
+  receivedTextResponseOutput: boolean;
+  textRetryCount: number;
 }
 
 const activeClients = new Map<string, LiveWebSocketClient>();
@@ -57,6 +61,9 @@ async function handleConnection(ws: WebSocket, sessionId: string): Promise<void>
     ws,
     sessionId,
     isActive: true,
+    awaitingTextResponse: false,
+    receivedTextResponseOutput: false,
+    textRetryCount: 0,
   };
 
   activeClients.set(sessionId, client);
@@ -78,6 +85,10 @@ async function handleConnection(ws: WebSocket, sessionId: string): Promise<void>
           sendError(ws, result.error || "Failed to send audio");
         }
       } else if (message.type === "text") {
+        client.lastTextTurn = message.text;
+        client.awaitingTextResponse = true;
+        client.receivedTextResponseOutput = false;
+        client.textRetryCount = 0;
         const result = await geminiLive.sendText(sessionId, message.text);
 
         if (!result.success) {
@@ -132,30 +143,97 @@ async function handleConnection(ws: WebSocket, sessionId: string): Promise<void>
 
 async function startReceiving(client: LiveWebSocketClient): Promise<void> {
   try {
-    for await (const response of geminiLive.receiveResponses(client.sessionId)) {
-      if (!client.isActive || client.ws.readyState !== WebSocket.OPEN) {
-        break;
+    while (client.isActive && client.ws.readyState === WebSocket.OPEN) {
+      let restarted = false;
+
+      for await (const response of geminiLive.receiveResponses(client.sessionId)) {
+        if (!client.isActive || client.ws.readyState !== WebSocket.OPEN) {
+          return;
+        }
+
+        if (response.type === "audio" && response.data) {
+          client.receivedTextResponseOutput ||= client.awaitingTextResponse;
+          sendMessage(client.ws, { type: "audio", data: response.data });
+        } else if (response.type === "text" && response.text) {
+          client.receivedTextResponseOutput ||= client.awaitingTextResponse;
+          sendMessage(client.ws, { type: "text", text: response.text });
+        } else if (response.type === "transcript" && response.text) {
+          client.receivedTextResponseOutput ||= client.awaitingTextResponse;
+          sendMessage(client.ws, { type: "transcript", text: response.text });
+        } else if (response.type === "functionCall" && response.functionCall) {
+          // Handle Computer Use function calls (Project Ghost)
+          await handleFunctionCall(client, response.functionCall);
+        } else if (response.type === "error") {
+          if (await tryRecoverTextTurn(client, response.error, response.retryable)) {
+            restarted = true;
+            break;
+          }
+
+          resetPendingTextTurn(client);
+          sendError(client.ws, response.error || "Connection to AI lost");
+          client.ws.close();
+          return;
+        } else if (response.type === "end") {
+          sendMessage(client.ws, { type: "end" });
+        }
       }
 
-      if (response.type === "audio" && response.data) {
-        sendMessage(client.ws, { type: "audio", data: response.data });
-      } else if (response.type === "text" && response.text) {
-        sendMessage(client.ws, { type: "text", text: response.text });
-      } else if (response.type === "transcript" && response.text) {
-        sendMessage(client.ws, { type: "transcript", text: response.text });
-      } else if (response.type === "functionCall" && response.functionCall) {
-        // Handle Computer Use function calls (Project Ghost)
-        await handleFunctionCall(client, response.functionCall);
-      } else if (response.type === "end") {
-        sendMessage(client.ws, { type: "end" });
+      if (!restarted) {
+        break;
       }
     }
   } catch (error) {
     console.error(`[Live WS] Error receiving responses for ${client.sessionId}:`, error);
     if (client.isActive && client.ws.readyState === WebSocket.OPEN) {
+      resetPendingTextTurn(client);
       sendError(client.ws, "Connection to AI lost");
+      client.ws.close();
     }
   }
+}
+
+function resetPendingTextTurn(client: LiveWebSocketClient): void {
+  client.awaitingTextResponse = false;
+  client.receivedTextResponseOutput = false;
+  client.textRetryCount = 0;
+}
+
+async function tryRecoverTextTurn(
+  client: LiveWebSocketClient,
+  error: string | undefined,
+  retryable: boolean | undefined,
+): Promise<boolean> {
+  if (
+    !retryable ||
+    !client.awaitingTextResponse ||
+    client.receivedTextResponseOutput ||
+    !client.lastTextTurn ||
+    client.textRetryCount >= 1
+  ) {
+    return false;
+  }
+
+  client.textRetryCount += 1;
+  console.warn(
+    `[Live WS] Retrying live turn for ${client.sessionId} after upstream error: ${error || "unknown error"}`,
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  const recreated = await geminiLive.recreateLiveSession(client.sessionId);
+  if (!recreated.success) {
+    console.error(`[Live WS] Failed to recreate session ${client.sessionId}:`, recreated.error);
+    return false;
+  }
+
+  const resent = await geminiLive.sendText(client.sessionId, client.lastTextTurn);
+  if (!resent.success) {
+    console.error(`[Live WS] Failed to resend text for ${client.sessionId}:`, resent.error);
+    return false;
+  }
+
+  client.receivedTextResponseOutput = false;
+  return true;
 }
 
 /**
@@ -308,6 +386,5 @@ function sendMessage(ws: WebSocket, message: object): void {
 function sendError(ws: WebSocket, error: string): void {
   sendMessage(ws, { type: "error", error });
 }
-
 
 

--- a/tests/gemini-live.test.ts
+++ b/tests/gemini-live.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { Modality } from "@google/genai";
+
+import {
+  buildLiveSessionRequestConfig,
+  getLiveCloseErrorMessage,
+  isRetryableLiveClose,
+} from "../server/integrations/gemini-live";
+
+describe("buildLiveSessionRequestConfig", () => {
+  it("uses audio-only native live responses and wraps system instructions as content", () => {
+    const config = buildLiveSessionRequestConfig({
+      voiceName: "Kore",
+      systemInstruction: "You are helpful.",
+    });
+
+    expect(config.responseModalities).toEqual([Modality.AUDIO]);
+    expect(config.speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName).toBe("Kore");
+    expect(config.systemInstruction).toEqual({
+      parts: [{ text: "You are helpful." }],
+    });
+  });
+
+  it("does not add video as a response modality for video streaming sessions", () => {
+    const config = buildLiveSessionRequestConfig({
+      enableVideoStreaming: true,
+      useGemini3: true,
+    });
+
+    expect(config.responseModalities).toEqual([Modality.AUDIO]);
+  });
+
+  it("keeps computer-use instructions in the content payload shape", () => {
+    const config = buildLiveSessionRequestConfig({
+      enableComputerUse: true,
+      systemInstruction: "You are helpful.",
+    });
+
+    expect(config.systemInstruction.parts[0].text).toContain("You are helpful.");
+    expect(config.systemInstruction.parts[0].text).toContain("computer_click");
+  });
+});
+
+describe("live close classification", () => {
+  it("marks service-unavailable closes as retryable", () => {
+    const closeInfo = {
+      code: 1011,
+      reason: "The service is currently unavailable.",
+    };
+
+    expect(isRetryableLiveClose(closeInfo)).toBe(true);
+    expect(getLiveCloseErrorMessage(closeInfo)).toBe(
+      "Live session closed: The service is currently unavailable.",
+    );
+  });
+
+  it("treats clean closes as non-errors", () => {
+    expect(isRetryableLiveClose({ code: 1000 })).toBe(false);
+    expect(getLiveCloseErrorMessage({ code: 1000 })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- restore retry-aware Gemini Live recovery on the main branch layout
- stop Twilio inbound SMS flows from defaulting to a retired Gemini model
- mark inbound SMS rows processed when reply generation is skipped or completes
- add Gemini Live regression coverage on main

## Notes
- main already contained the chat wrapping, dictation, and communications-page client fixes from earlier work
- this PR ports the remaining server-side fixes and tests onto the default branch cleanly